### PR TITLE
Have setup.py build JS code when package is installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pyc
 orig
 .deploy
 interactwel_django_app.egg-info/
+build

--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ pip install -r requirements.txt
 python setup.py develop
 ```
 
-Now build the Vue JS app
-
-```
-cd interactwel/
-npm run build
-```
+Note: `python setup.py develop` also builds the Vue JS app.
 
 Go back to the airavata-django-portal and start the server
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,28 @@
+import distutils
+import os
+import subprocess
+
 import setuptools
+from setuptools.command.develop import develop
+from setuptools.command.install import install
+
+def build_js():
+    subprocess.check_call(["npm", "install"], cwd=os.path.join(os.getcwd(), "interactwel"))
+    subprocess.check_call(["npm", "run", "build"], cwd=os.path.join(os.getcwd(), "interactwel"))
+
+# Build JS code when this package is installed in virtual env
+# https://stackoverflow.com/a/36902139
+class BuildJSDevelopCommand(develop):
+    def run(self):
+        self.announce("Building JS code", level=distutils.log.INFO)
+        build_js()
+        super().run()
+
+class BuildJSInstallCommand(install):
+    def run(self):
+        self.announce("Building JS code", level=distutils.log.INFO)
+        build_js()
+        super().run()
 
 setuptools.setup(
     name="interactwel-django-app",
@@ -15,4 +39,8 @@ setuptools.setup(
 [airavata.djangoapp]
 interactwel = interactwel.apps:InteractwelAppConfig
 """,
+    cmdclass={
+        'develop': BuildJSDevelopCommand,
+        'install': BuildJSInstallCommand,
+    }
 )


### PR DESCRIPTION
Add commands to `python setup.py develop` and `python setup.py install` to build the Vue JS app when the python package is installed. This will streamline deployment of the app into the Airavata Django Portal.