### PR TITLE
Force creation of a vendors chunk

### DIFF
--- a/interactwel/templates/interactwel/application.html
+++ b/interactwel/templates/interactwel/application.html
@@ -11,6 +11,7 @@
 {% endblock %}
 
 {% block css %}
+{% render_bundle 'chunk-vendors' 'css' 'INTERACTWEL' %}
 {% render_bundle 'app' 'css' 'INTERACTWEL' %}
 {% endblock %}
 
@@ -23,5 +24,6 @@
         });
     </script>
     {{ block.super }}
+    {% render_bundle 'chunk-vendors' 'js' 'INTERACTWEL' %}
     {% render_bundle 'app' 'js' 'INTERACTWEL' %}
 {% endblock %}

--- a/interactwel/vue.config.js
+++ b/interactwel/vue.config.js
@@ -10,11 +10,37 @@ module.exports = {
     devServer: {
         disableHostCheck: true
     },
+  configureWebpack: {
+    optimization: {
+      /*
+       * Force creating a vendor bundle so we can load the 'app' and 'vendor'
+       * bundles on development as well as production using django-webpack-loader.
+       * Otherwise there is no vendor bundle on development and we would need
+       * some template logic to skip trying to load it.
+       * See also: https://bitbucket.org/calidae/dejavu/src/d63d10b0030a951c3cafa6b574dad25b3bef3fe9/%7B%7Bcookiecutter.project_slug%7D%7D/frontend/vue.config.js?at=master&fileviewer=file-view-default#vue.config.js-27
+       */
+      splitChunks: {
+        cacheGroups: {
+          vendors: {
+            name: 'chunk-vendors',
+            test: /[\\/]node_modules[\\/]/,
+            priority: -10,
+            chunks: 'initial'
+          },
+        // there is only one entry point so common chunk isn't needed
+        //   common: {
+        //     name: 'chunk-common',
+        //     minChunks: 2,
+        //     priority: -20,
+        //     chunks: 'initial',
+        //     reuseExistingChunk: true
+        //   }
+        }
+      }
+    }
+  },
 
     chainWebpack: config => {
-
-    config.optimization
-    .splitChunks(false)
 
 config
     .plugin('BundleTracker')


### PR DESCRIPTION
Production build seems to require a vendors chunk. Force creation of
vendors chunk so it is created in dev mode too and bundle can be loaded
in application.html template.