### PR TITLE
Making rename migration atomic for older versions of SQLite

### DIFF
--- a/interactwel/migrations/0005_auto_20200206_1525.py
+++ b/interactwel/migrations/0005_auto_20200206_1525.py
@@ -7,6 +7,7 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
+    atomic = False
 
     dependencies = [
         ('interactwel', '0004_interactweladaptationstory_interactweldocumentation_interactwelinstructionalvideo'),


### PR DESCRIPTION
When testing with Django 2.2 I ran into the following error when running tests:

```
django.db.utils.NotSupportedError: Renaming the 'interactwel_user' table while in a transaction is not supported on SQLite < 3.26 because it would break referential integrity. Try adding `atomic = False` to the Migration class.
```

To fix this I followed the advice and added `atomic = False` to this Migration class which renames the interactwel_user table.