### PR TITLE
Enabling few PUT requests

### DIFF
--- a/interactwel/views.py
+++ b/interactwel/views.py
@@ -643,6 +643,20 @@ class FeedbackViewSet(viewsets.ViewSet):
             }
             return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
+    def update(self, request, pk=None):
+        feedback = InteractwelFeedback.objects.all().filter(feedback_id=pk)
+        if len(feedback) == 0:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        else:
+            feedback.update(
+                date_created=request.data["date_created"],
+                date_modified=request.data["date_modified"],
+                feasibilty=request.data["feasibilty"],
+                comments=request.data["comments"],
+                rating=request.data["rating"]
+            )
+            return Response(InteractwelFeedbackSerializer(feedback[0], many=False).data, status=status.HTTP_201_CREATED)
+
     def get_queryset(self):
         queryset = InteractwelFeedback.objects.all()
         user_id = self.request.query_params.get('user_id', None)
@@ -953,3 +967,14 @@ class ProjectJoinRequestViewSet(viewsets.ViewSet):
                 "errors": serializer.errors,
             }
             return Response(data, status=status.HTTP_400_BAD_REQUEST)
+
+    def update(self, request, pk=None):
+        project_join_request = InteractwelProjectJoinRequest.objects.all().filter(project_id=pk)
+        if len(project_join_request) == 0:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        else:
+            project_join_request.update(
+                status=request.data["status"]
+            )
+            return Response(InteractwelProjectJoinRequestSerializer(project_join_request[0], many=False).data,
+                            status=status.HTTP_201_CREATED)

--- a/interactwel/views.py
+++ b/interactwel/views.py
@@ -551,6 +551,18 @@ class SelectedPlanViewSet(viewsets.ViewSet):
             }
             return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
+    def update(self, request, pk=None):
+        selected_plan = InteractwelSelectedPlan.objects.all().filter(selected_plan_id=pk)
+        if len(selected_plan) == 0:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        else:
+            selected_plan.update(
+                goals=request.data["goals"],
+                timestamp=request.data["timestamp"]
+            )
+            return Response(InteractwelSelectedPlanSerializer(selected_plan[0], many=False).data,
+                            status=status.HTTP_201_CREATED)
+
     def get_queryset(self):
         queryset = InteractwelSelectedPlan.objects.all()
         project_id = self.request.query_params.get('project_id', None)

--- a/interactwel/views.py
+++ b/interactwel/views.py
@@ -430,17 +430,17 @@ class ProjectUserViewSet(viewsets.ViewSet):
             return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
     def update(self, request, pk=None):
-        projectuser = InteractwelProjectUser.objects.all().filter(user_id=pk, project_id=request.data["project_id"])
-        if len(projectuser) == 0:
+        project_user = InteractwelProjectUser.objects.all().filter(user_id=pk, project_id=request.data["project_id"])
+        if len(project_user) == 0:
             return Response(status=status.HTTP_404_NOT_FOUND)
         else:
-            projectuser.update(
+            project_user.update(
                 status=request.data["status"],
                 role=request.data["role"],
                 sector=request.data["sector"],
                 actor=request.data["actor"]
             )
-            return Response(InteractwelProjectUserSerializer(projectuser[0], many=False).data,
+            return Response(InteractwelProjectUserSerializer(project_user[0], many=False).data,
                             status=status.HTTP_201_CREATED)
 
 

--- a/interactwel/views.py
+++ b/interactwel/views.py
@@ -481,6 +481,15 @@ class PlanViewSet(viewsets.ViewSet):
         serializer = InteractwelPlanSerializer(project)
         return Response(serializer.data)
 
+    def update(self, request, pk=None):
+        plan = InteractwelPlan.objects.all().filter(plan_id=pk, project_id=request.data["project_id"])
+        if len(plan) == 0:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        else:
+            plan.update(plan_json=request.data["plan_json"])
+            serializer = InteractwelPlanSerializer(plan[0], many=False)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
     def create(self, request):
         serializer = InteractwelPlanSerializer(data=request.data)
         if serializer.is_valid():

--- a/interactwel/views.py
+++ b/interactwel/views.py
@@ -468,6 +468,19 @@ class ProjectDataViewSet(viewsets.ViewSet):
             }
             return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
+    def update(self, request, pk=None):
+        project_data = InteractwelProjectData.objects.all().filter(project_id=pk)
+        if len(project_data) == 0:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        else:
+            project_data.update(
+                name=request.data["name"],
+                data_type=request.data["data_type"],
+                data=request.data["data"]
+            )
+            return Response(InteractwelProjectDataSerializer(project_data[0], many=False).data,
+                            status=status.HTTP_201_CREATED)
+
 
 class PlanViewSet(viewsets.ViewSet):
     def list(self, request):


### PR DESCRIPTION
```
PUT /interactwel/api/plans/1/?format=json
{
    "plan_json": "{}",
    "project_id": 1
}

PUT /interactwel/api/projectdata/1/?format=json
{
    "name": "",
    "data_type": "",
    "data": "",
}

PUT /interactwel/api/selectedplans/1/?format=json
{
    "action_mapping": [
        {
            "id": 1,
            "selected_plan_id": 1,
            "actor_id": 1,
            "action_id": 2
        }
    ]
}

PUT /interactwel/api/feedbacks/1/?format=json
{
    "feasibilty": "1",
    "comments": null,
    "rating": "3"
}


PUT /interactwel/api/projectjoinrquests/1/?format=json
{
    "status": "",
     user_id: 1
}

```